### PR TITLE
Fix joinmsg_id value to be NULL, not a zero-length string

### DIFF
--- a/Conferences.class.php
+++ b/Conferences.class.php
@@ -261,9 +261,13 @@ class Conferences extends \FreePBX_Helpers implements BMO {
 	 * @param {string} $music        MOH to play on hold
 	 * @param {int} $users
 	 */
-	public function addConference($room,$name,$userpin,$adminpin,$options,$joinmsg_id = null,$music = '',$users = 0,$language='') {
+	public function addConference($room,$name,$userpin,$adminpin,$options,$joinmsg_id = NULL,$music = '',$users = 0,$language='') {
 		$sql = "INSERT INTO meetme (exten,description,userpin,adminpin,options,joinmsg_id,music,users,language) values (?,?,?,?,?,?,?,?,?)";
 		$sth = $this->db->prepare($sql);
+		/* fixup joinmsg_id to be NULL, not an empty string */
+		if ($joinmsg_id == '') {
+			$joinmsg_id = NULL;
+		}
 		$sth->execute(array($room,$name,$userpin,$adminpin,$options,$joinmsg_id,$music,$users,$language));
 		$language = !is_null($language) ? $language : "";
 		$this->astman->database_put('CONFERENCE/'.$room,'language',$language);


### PR DESCRIPTION
In a modern mysql engine, attempting to insert an empty string into an "int" column will fail.  Make sure that if no value is set, we insert as NULL.

![screen shot 2016-07-10 at 3 41 32 pm](https://cloud.githubusercontent.com/assets/1443898/16715730/8ecfa53a-46b6-11e6-992f-cd6871b0104d.png)
